### PR TITLE
WIP: Initial Clean Pandas Accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,175 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+.idea/clean_pandas.iml
+.idea/codeStyles/
+.idea/inspectionProfiles/
+.idea/markdown-navigator.xml
+.idea/markdown-navigator/
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - "3.6"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# clean_pandas
+# Clean Pandas
 Pandas accessor for replacing, removing, or encrypting a DataFrame or Series that contains Personally Identifiable Information (PII) or Protected Health Information (PHI)
+
+## Dependencies
+
+* [Faker](https://github.com/joke2k/faker)
+* [Scrubadub](https://github.com/datascopeanalytics/scrubadub)
+* [cryptography](https://github.com/pyca/cryptography)
+
+## Clean Type Options
+
+* ```encrypt``` (default) - Utilizes the [cryptography](https://github.com/pyca/cryptography) library and uses Fernet (symmetric encryption)
+  * **NOTE**: You must use the ```serialize_encryption_key``` before ending your REPL or program in order to decrypt
+* ```faker``` - Utilizes the [Faker](https://github.com/joke2k/faker) library and requires user denote the Faker "fake" to use
+* ```scrubadub``` - Utilizes the [Scrubadub](https://github.com/datascopeanalytics/scrubadub) library to detect and replace PII
+* ```truncate``` - Truncates the data by casting to a string, if possible, and recast to original type if possible.  Returns ```None``` if truncation is longer than the value length.  Returns the string value if cannot be cast back to original type
+
+
+## Basic Usage
+
+```python
+>>> from clean_pandas import CleanPandas
+>>> import pandas as pd
+
+>>> test_df = pd.DataFrame({"first_name": ["Charles", "Stephen"], "last_name": ["Darwin", "Hawking"], 'ssn': ['555-55-5555', '123-45-6789']})
+
+>>> test_df.clean_pandas.clean_series('ssn')
+0    b'gAAAAABbextrtJcQfOt37HK7pEISBokuh9ndWwGhvZpv...
+1    b'gAAAAABbextrHo7qFr6DIZ0FlvVyO73HOmOYujKsv6vS...
+Name: ssn, dtype: object
+
+>>> test_df.clean_pandas.clean_series('last_name', clean_type='faker', faker_type='first_name')
+0     Joshua
+1    Michael
+Name: last_name, dtype: object
+
+>>> test_df.clean_pandas.clean_series('ssn', clean_type='scrubadub')
+0    {{SSN}}
+1    {{SSN}}
+Name: ssn, dtype: object
+
+>>> test_df.clean_pandas.clean_series('ssn', clean_type='truncate', trunc_length=7, trunc_from_end=False)
+0    5555
+1    6789
+Name: ssn, dtype: object
+
+```
+
+## Batch Clean
+
+```python
+>>> cleaner_params = [{'series_name': 'last_name', 'clean_type': 'faker', 'faker_type': 'last_name'}, {'series_name': 'ssn', 'clean_type': 'scrubadub'}]
+
+>>> test_df.clean_pandas.clean_dataframe(cleaner_params)
+  first_name last_name      ssn
+0    Charles   Pacheco  {{SSN}}
+1    Stephen     Hogan  {{SSN}}
+```
+
+## License
+
+MIT License
+
+Copyright (c) 2018 Aaron Burgess
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clean_pandas/__init__.py
+++ b/clean_pandas/__init__.py
@@ -1,0 +1,1 @@
+from clean_pandas.clean_pandas import CleanPandas

--- a/clean_pandas/clean_pandas.py
+++ b/clean_pandas/clean_pandas.py
@@ -13,7 +13,7 @@ class UnknownCleanType(Exception):
     pass
 
 
-@pd.tools.util.pd.api.extensions.register_dataframe_accessor('clean_pandas')
+@pd.api.extensions.register_dataframe_accessor('clean_pandas')
 class CleanPandas:
     def __init__(self, pandas_object: Union[pd.DataFrame]):
         self._pd_obj = pandas_object
@@ -21,100 +21,104 @@ class CleanPandas:
         self._fernet = Fernet(self._key)
         self._faker = Faker()
 
-        def _encrypt_value(value: Any) -> bytes:
-            """
-            Take an input value, convert to bytes, and encrypt as bytes
+    def _encrypt_value(self, value: Any) -> bytes:
+        """
+        Take an input value, convert to bytes, and encrypt as bytes
 
-            Args:
-                value: Incoming value from Pandas Series
+        Args:
+            value: Incoming value from Pandas Series
 
-            Returns:
-                An encrypted bytes object
-            """
-            return self._fernet.encrypt(str(value).encode())
+        Returns:
+            An encrypted bytes object
+        """
+        return self._fernet.encrypt(str(value).encode())
 
-        def _fake_value(faker_type: str) -> Any:
-            """
-            Replace an input value with a fake output value of a matching type
+    def _fake_value(self, faker_type: str) -> Any:
+        """
+        Replace an input value with a fake output value of a matching type
 
-            Args:
-                faker_type: Faker provider type to use
+        Args:
+            faker_type: Faker provider type to use
 
-            Returns:
-                Same data type as incoming but a fake value
-            """
-            return self._faker.__dict__[faker_type]()
+        Returns:
+            Same data type as incoming but a fake value
+        """
+        return self._faker.__dict__[faker_type]()
 
-        def _truncate_value(value: Any,
-                            dtype: Any,
-                            trunc_length: int,
-                            trunc_from_end: bool) -> Any:
-            """
-            Truncates a given value given a truncation length and direction from which to truncate
+    def _truncate_value(self, value: Any,
+                        dtype: Any,
+                        trunc_length: int,
+                        trunc_from_end: bool) -> Any:
+        """
+        Truncates a given value given a truncation length and direction from which to truncate
 
-            Args:
-                value: Incoming value from Pandas Series
-                dtype: Numpy object type
-                trunc_length: Length of characters to truncate
-                trunc_from_end: Boolean indicating whether to truncate from end of value or start
+        Args:
+            value: Incoming value from Pandas Series
+            dtype: Numpy object type
+            trunc_length: Length of characters to truncate
+            trunc_from_end: Boolean indicating whether to truncate from end of value or start
 
-            Returns:
-                A truncated value
-            """
-            trunc_index = len(value) - trunc_length
-            truncate_value = str(value)[:trunc_index] if trunc_from_end else str(value)[trunc_index:]
+        Returns:
+            A truncated value
+        """
+        trunc_index = len(value) - trunc_length
+        truncate_value = str(value)[:trunc_index] if trunc_from_end else str(value)[trunc_index:]
 
-            if dtype in [numpy.datetime64, numpy.object, numpy.object_]:
-                return truncate_value
+        if dtype in [numpy.datetime64, numpy.object, numpy.object_]:
+            return truncate_value
+        else:
+            return dtype(truncate_value)
+
+    def _create_unique_value_dict(self, column_name: str,
+                                  clean_type: str,
+                                  faker_type: str,
+                                  trunc_length: int = 0,
+                                  trunc_from_end=True) -> Dict[Any, Any]:
+        """
+        Take the unique values in a series and perform the desired cleaning operations
+
+        Args:
+            clean_type: String indicating 'encrypt', 'replace', 'truncate'
+            faker_type: String indicating faker provider to use
+            trunc_length: Used if clean_type is 'truncate', indicates how many characters to remove
+            trunc_from_end: Truncate from the end, will truncate from the start if False
+
+        Returns:
+            Dictionary with unique values as keys and replacement values as dictionary values
+        """
+        replacement_xwalk_dict = {}
+
+        for value in self._pd_obj[column_name].unique():
+            if clean_type == 'encrypt':
+                new_value = self._encrypt_value(value)
+            elif clean_type == 'faker':
+                new_value = self._fake_value(faker_type)
+            elif clean_type == 'truncate':
+                new_value = self._truncate_value(value, self._pd_obj[column_name].dtype.type,
+                                            trunc_length, trunc_from_end)
             else:
-                return dtype(truncate_value)
+                raise UnknownCleanType("Clean type must be 'encrypt', 'faker', or 'truncate'")
 
-        def _create_unique_value_dict(column_name: str,
-                                      faker_type: str,
-                                      clean_type: str = 'encrypt',
-                                      trunc_length: int = 0,
-                                      trunc_from_end=True) -> Dict[Any, Any]:
-            """
-            Take the unique values in a series and perform the desired cleaning operations
+            replacement_xwalk_dict[value] = new_value
 
-            Args:
-                clean_type: String indicating 'encrypt', 'replace', 'truncate'
-                trunc_length: Used if clean_type is 'truncate', indicates how many characters to remove
-                trunc_from_end: Truncate from the end, will truncate from the start if False
+        return replacement_xwalk_dict
 
-            Returns:
-                Dictionary with unique values as keys and replacement values as dictionary values
-            """
-            replacement_xwalk_dict = {}
+    def clean_series(self, series_name: str, clean_type: str = 'encrypt', faker_type: Union[str, None] = None,
+                     trunc_length: int=0, trunc_from_end: bool = True) -> pd.Series:
+        """
+        Takes the unique values in a given series, applies the clean_type and replaces all values in the
+        given series with the new "clean" values
 
-            for value in self._pd_obj[column_name].unique():
-                if clean_type == 'encrypt':
-                    new_value = _encrypt_value(value)
-                elif clean_type == 'faker':
-                    new_value = _fake_value(faker_type)
-                elif clean_type == 'truncate':
-                    new_value = _truncate_value(value, self._pd_obj[column_name].dtype.type,
-                                                trunc_length, trunc_from_end)
-                else:
-                    raise UnknownCleanType("Clean type must be 'encrypt', 'faker', or 'truncate'")
+        Args:
+            series_name: Pandas series name
+            clean_type: 'encrypt', 'faker', 'truncate' are the options
+            faker_type: Faker provider type to use
+            trunc_length: Length of characters to truncate
+            trunc_from_end: Boolean that indicates if truncation should start from the end, defaults to True
 
-                replacement_xwalk_dict[value] = new_value
-
-            return replacement_xwalk_dict
-
-        def clean_series(series_name: str, clean_type: str, faker_type: str,
-                         trunc_length: int = 0, trunc_from_end: bool = True):
-            """
-            Takes the unique values in a given series, applies the clean_type and replaces all values in the
-            given series with the new "clean" values
-
-            Args:
-                series_name: Pandas series name
-                clean_type: 'encrypt', 'faker', 'truncate' are the options
-                faker_type: Faker provider type to use
-                trunc_length: Leng
-                trunc_from_end:
-
-            Returns:
-
-            """
+        Returns:
+            Returns new Series with updated values
+        """
+        value_dict = self._create_unique_value_dict(series_name, faker_type, clean_type, trunc_length, trunc_from_end)
+        new_series = self._pd_obj[series_name].replace(value_dict)
+        return new_series

--- a/clean_pandas/clean_pandas.py
+++ b/clean_pandas/clean_pandas.py
@@ -1,22 +1,85 @@
-from typing import Dict, Union, List, Any
+from typing import Dict, Union, Any
+from datetime import datetime
+
 import pandas as pd
+import numpy
+
+from cryptography.fernet import Fernet
+from faker import Faker
+
+
+class UnknownCleanType(Exception):
+    """Custom Exception for unknown clean type"""
+    pass
 
 
 @pd.tools.util.pd.api.extensions.register_dataframe_accessor('clean_pandas')
 class CleanPandas:
     def __init__(self, pandas_object: Union[pd.DataFrame]):
         self._pd_obj = pandas_object
+        self._key = Fernet.generate_key()
+        self._fernet = Fernet(self._key)
+        self._faker = Faker()
+
+        def _encrypt_value(value: Any) -> bytes:
+            """
+            Take an input value, convert to bytes, and encrypt as bytes
+
+            Args:
+                value: Incoming value from Pandas Series
+
+            Returns:
+                An encrypted bytes object
+            """
+            return self._fernet.encrypt(str(value).encode())
+
+        def _fake_value(faker_type: str) -> Any:
+            """
+            Replace an input value with a fake output value of a matching type
+
+            Args:
+                faker_type: Faker provider type to use
+
+            Returns:
+                Same data type as incoming but a fake value
+            """
+            return self._faker.__dict__[faker_type]()
+
+        def _truncate_value(value: Any,
+                            dtype: Any,
+                            trunc_length: int,
+                            trunc_from_end: bool) -> Any:
+            """
+            Truncates a given value given a truncation length and direction from which to truncate
+
+            Args:
+                value: Incoming value from Pandas Series
+                dtype: Numpy object type
+                trunc_length: Length of characters to truncate
+                trunc_from_end: Boolean indicating whether to truncate from end of value or start
+
+            Returns:
+                A truncated value
+            """
+            trunc_index = len(value) - trunc_length
+            truncate_value = str(value)[:trunc_index] if trunc_from_end else str(value)[trunc_index:]
+
+            if dtype in [numpy.datetime64, numpy.object, numpy.object_]:
+                return truncate_value
+            else:
+                return dtype(truncate_value)
 
         def _create_unique_value_dict(column_name: str,
-                                      clean_type: str ='encrypt',
-                                      trunc_level: int = 0,
+                                      faker_type: str,
+                                      clean_type: str = 'encrypt',
+                                      trunc_length: int = 0,
                                       trunc_from_end=True) -> Dict[Any, Any]:
             """
             Take the unique values in a series and perform the desired cleaning operations
 
             Args:
                 clean_type: String indicating 'encrypt', 'replace', 'truncate'
-                trunc_level: Used if clean_type is 'truncate', indicates how many characters to remove
+                trunc_length: Used if clean_type is 'truncate', indicates how many characters to remove
                 trunc_from_end: Truncate from the end, will truncate from the start if False
 
             Returns:
@@ -25,5 +88,33 @@ class CleanPandas:
             replacement_xwalk_dict = {}
 
             for value in self._pd_obj[column_name].unique():
-                ## TODO: Using replacement_xwalk_dict, make the value object the key and apply the clean_type to the same object as the dictionary value
-                replacement_xwalk_dict[value] = value
+                if clean_type == 'encrypt':
+                    new_value = _encrypt_value(value)
+                elif clean_type == 'faker':
+                    new_value = _fake_value(faker_type)
+                elif clean_type == 'truncate':
+                    new_value = _truncate_value(value, self._pd_obj[column_name].dtype.type,
+                                                trunc_length, trunc_from_end)
+                else:
+                    raise UnknownCleanType("Clean type must be 'encrypt', 'faker', or 'truncate'")
+
+                replacement_xwalk_dict[value] = new_value
+
+            return replacement_xwalk_dict
+
+        def clean_series(series_name: str, clean_type: str, faker_type: str,
+                         trunc_length: int = 0, trunc_from_end: bool = True):
+            """
+            Takes the unique values in a given series, applies the clean_type and replaces all values in the
+            given series with the new "clean" values
+
+            Args:
+                series_name: Pandas series name
+                clean_type: 'encrypt', 'faker', 'truncate' are the options
+                faker_type: Faker provider type to use
+                trunc_length: Leng
+                trunc_from_end:
+
+            Returns:
+
+            """

--- a/clean_pandas/clean_pandas.py
+++ b/clean_pandas/clean_pandas.py
@@ -1,0 +1,29 @@
+from typing import Dict, Union, List, Any
+import pandas as pd
+
+
+@pd.tools.util.pd.api.extensions.register_dataframe_accessor('clean_pandas')
+class CleanPandas:
+    def __init__(self, pandas_object: Union[pd.DataFrame]):
+        self._pd_obj = pandas_object
+
+        def _create_unique_value_dict(column_name: str,
+                                      clean_type: str ='encrypt',
+                                      trunc_level: int = 0,
+                                      trunc_from_end=True) -> Dict[Any, Any]:
+            """
+            Take the unique values in a series and perform the desired cleaning operations
+
+            Args:
+                clean_type: String indicating 'encrypt', 'replace', 'truncate'
+                trunc_level: Used if clean_type is 'truncate', indicates how many characters to remove
+                trunc_from_end: Truncate from the end, will truncate from the start if False
+
+            Returns:
+                Dictionary with unique values as keys and replacement values as dictionary values
+            """
+            replacement_xwalk_dict = {}
+
+            for value in self._pd_obj[column_name].unique():
+                ## TODO: Using replacement_xwalk_dict, make the value object the key and apply the clean_type to the same object as the dictionary value
+                replacement_xwalk_dict[value] = value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Cython==0.28.5
+cryptography==2.3.1
+Faker==0.9.0
+pandas==0.23.4
+scrubadub==1.2.0
+pytest==3.7.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup
+
+setup(
+    name='clean_pandas',
+    version='0.1.0',
+    packages=['tests', 'clean_pandas'],
+    url='https://github.com/awburgess/clean_pandas',
+    license='MIT License',
+    author='Aaron Burgess',
+    author_email='geoburge@gmail.com',
+    description=' Pandas accessor for replacing, removing, or encrypting a DataFrame or Series that contains Personally Identifiable Information (PII) or Protected Health Information (PHI)',
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        'Faker',
+        'cryptography',
+        'scrubadub',
+    ]
+)

--- a/tests/resources/test_data.csv
+++ b/tests/resources/test_data.csv
@@ -1,6 +1,6 @@
 some_id,ssn,dob,street_address,city,state,postal,first_name,last_name,email,income
 1,423-11-4567,1979-12-07,20 Main St,Windsor,VT,05001,Mario,Lopez,mlopez@gmail.com,75225
 2,123-45-6789,1968-04-12,503 Something Ave,Chicago,IL,23410,Tornado,Jones,tor_da_j@hotmail.com,54000
-3,435-796-9283,1940-01-15,1234 Hola Rd,Clooney,RI,03451,Roger,Throwback,throwit@yahoo.com,125145
+3,435-796-9283,1940-01-15,1234 Hola Rd,Clooney,RI,03451,Roger,Topper,throwit@yahoo.com,125145
 4,769-343-1123,2017-01-20,18 Dakota Fanning Pl,Paris,TX,54832,Daniel,Tiger,bday@gmail.com,80000
 5,555-55-5555,2002-09-28,21 Senate Ave,Denver,CO,12345,Elmo,Sesame,elmosworld@gmail.com,45250

--- a/tests/resources/test_data.csv
+++ b/tests/resources/test_data.csv
@@ -1,0 +1,6 @@
+some_id,ssn,dob,street_address,city,state,postal,first_name,last_name,email,income
+1,423-11-4567,1979-12-07,20 Main St,Windsor,VT,05001,Mario,Lopez,mlopez@gmail.com,75225
+2,123-45-6789,1968-04-12,503 Something Ave,Chicago,IL,23410,Tornado,Jones,tor_da_j@hotmail.com,54000
+3,435-796-9283,1940-01-15,1234 Hola Rd,Clooney,RI,03451,Roger,Throwback,throwit@yahoo.com,125145
+4,769-343-1123,2017-01-20,18 Dakota Fanning Pl,Paris,TX,54832,Daniel,Tiger,bday@gmail.com,80000
+5,555-55-5555,2002-09-28,21 Senate Ave,Denver,CO,12345,Elmo,Sesame,elmosworld@gmail.com,45250

--- a/tests/test_clean_pandas.py
+++ b/tests/test_clean_pandas.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+import pandas as pd
+
+from clean_pandas import CleanPandas
+
+
+@pytest.fixture
+def test_data() -> pd.DataFrame:
+    """
+    Fixture that returns a test dataframe from dummy data
+
+    Returns:
+        Pandas DataFrame with dummy data for testing
+    """
+    data = Path(__file__).parent / 'resources/test_data.csv'
+    return pd.read_csv(data, dtype=str, parse_dates=True)

--- a/tests/test_clean_pandas.py
+++ b/tests/test_clean_pandas.py
@@ -1,12 +1,15 @@
 from pathlib import Path
+from datetime import datetime
+from typing import NoReturn
 
 import pytest
 import pandas as pd
+import numpy as np
 
 from clean_pandas import CleanPandas
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def test_data() -> pd.DataFrame:
     """
     Fixture that returns a test dataframe from dummy data
@@ -15,4 +18,193 @@ def test_data() -> pd.DataFrame:
         Pandas DataFrame with dummy data for testing
     """
     data = Path(__file__).parent / 'resources/test_data.csv'
-    return pd.read_csv(data, dtype=str, parse_dates=True)
+    return pd.read_csv(data, dtype={'postal': str},
+                       converters={'dob': lambda x:
+                       datetime.strptime(x, '%Y-%m-%d').date()})
+
+
+def test_ssn_clean_series_faker() -> NoReturn:
+    """
+    Assert that fake SSNs replace all original
+
+    """
+    test_df = test_data()
+
+    fake_values = test_df.clean_pandas.clean_series('ssn', clean_type='faker',
+                                                    faker_type='ssn').tolist()
+
+    for value in test_df.ssn.values:
+        assert value not in fake_values
+
+
+def test_ssn_clean_series_encrypt() -> NoReturn:
+    """
+    Assert that fake SSNs are replaced by encrypted values
+
+    """
+    test_df = test_data()
+
+    encrypted_values = test_df.clean_pandas.clean_series(
+        'ssn', clean_type='encrypt').tolist()
+
+    assert all([isinstance(val, bytes) for val in encrypted_values])
+
+
+def test_ssn_clean_series_truncate() -> NoReturn:
+    """
+    Assert that all SSN are truncated based on settings
+
+    """
+    test_df = test_data()
+
+    truncated_values = test_df.clean_pandas.clean_series('ssn',
+                                                         clean_type='truncate',
+                                                         trunc_length=5)
+
+    assert all([len(val) != 11 for val in truncated_values])
+
+
+def test_dob_clean_series_faker() -> NoReturn:
+    """
+    Assert that the dob series is replaced with datetime objects
+
+    """
+    test_df = test_data()
+
+    fake_dates = test_df.clean_pandas.clean_series('dob',
+                                                   clean_type='faker',
+                                                   faker_type='date_time')
+
+    assert all([isinstance(d, datetime) for d in fake_dates])
+
+
+def test_dob_clean_series_truncate() -> NoReturn:
+    """
+    Assert that the dob series is truncated and returned as string
+
+    """
+    test_df = test_data()
+
+    truncated_values = test_df.clean_pandas.clean_series('dob',
+                                                         clean_type='truncate',
+                                                         trunc_length=4,
+                                                         trunc_from_end=False)
+
+    assert all([val.startswith('-') for val in truncated_values.tolist()])
+
+
+def test_postal_clean_series_faker() -> NoReturn:
+    """
+    Assert that the postal series is replaced with fake data.
+
+    """
+    test_df = test_data()
+
+    fake_values = test_df.clean_pandas.clean_series('postal',
+                                                    clean_type='faker',
+                                                    faker_type='zipcode')
+
+    for value in test_df.postal.values:
+        assert value not in fake_values
+
+
+def test_first_name_clean_series_scrubadub() -> NoReturn:
+    """
+    Assert that first name values are replaced by Scrubadub place holders
+
+    """
+    test_df = test_data()
+
+    scrubbed_first_name = test_df.clean_pandas.clean_series(
+        'first_name', clean_type='scrubadub'
+    )
+
+    assert scrubbed_first_name.unique() == '{{NAME}}'
+
+
+def test_last_name_clean_series_scrubadub() -> NoReturn:
+    """
+    Assert that last name values are replaced by Scrubadub place holders
+
+    """
+    test_df = test_data()
+
+    scrubbed_last_name = test_df.clean_pandas.clean_series(
+        'last_name',
+        clean_type='scrubadub')
+
+    assert scrubbed_last_name.unique() == '{{NAME}}'
+
+
+def test_ssn_clean_series_scrubadub() -> NoReturn:
+    """
+    Assert that SSN is redacted with Scrubadub placeholders
+
+    """
+    test_df = test_data()
+
+    scrubbed_ssn = test_df.clean_pandas.clean_series('ssn',
+                                                     clean_type='scrubadub')\
+        .unique()
+
+    assert '{{SSN}}' in scrubbed_ssn
+    # We have malformed SSN in the data, so Scrubadub picks
+    # up some as phone numbers
+    assert '{{PHONE}}' in scrubbed_ssn
+
+
+def test_some_id_clean_series_truncate_too_much() -> NoReturn:
+    """
+    Ensure that truncating a value by more than the characters
+    returns all None
+
+    """
+    test_df = test_data()
+
+    series_test = test_df.clean_pandas.clean_series('some_id',
+                                                    clean_type='truncate',
+                                                    trunc_length=4)
+
+    assert series_test.dtype.type == np.object_
+
+
+def test_income_clean_series_truncate() -> NoReturn:
+    """
+    Ensure that truncating an int or float value returns the same unless
+    truncated past value length
+
+    """
+    test_df = test_data()
+
+    income_clean_series = test_df.clean_pandas.clean_series(
+        'income',
+        clean_type='truncate',
+        trunc_length=3)
+
+    assert income_clean_series.dtypes.type == np.int64
+
+
+def test_clean_dataframe_names_email_ssn() -> NoReturn:
+    """
+    Assert that, given a parameter list, the clean dataframe method
+    cleans the series correctly
+
+    """
+    test_df = test_data()
+
+    params_list_of_dicts = [
+        {'series_name': 'first_name', 'clean_type': 'scrubadub'},
+        {'series_name': 'last_name', 'clean_type': 'scrubadub'},
+        {'series_name': 'email', 'clean_type': 'faker', 'faker_type': 'email'},
+        {'series_name': 'street_address', 'clean_type': 'encrypt'},
+        {'series_name': 'ssn', 'clean_type': 'truncate', 'trunc_length': 7,
+         'trunc_from_end': False}
+    ]
+
+    clean_df = test_df.clean_pandas.clean_dataframe(params_list_of_dicts)
+
+    assert clean_df.first_name.unique() == '{{NAME}}'
+    assert clean_df.last_name.unique() == '{{NAME}}'
+    assert (clean_df.merge(test_df, on='email', how='inner')).shape[0] == 0
+    assert all([isinstance(value, bytes) for value in clean_df.street_address])
+    assert all([len(value) <= 5 for value in clean_df.ssn])


### PR DESCRIPTION
### Why?

Protected data can glean great insights but requires protective measures.  The point of this ```pandas``` accessor is to allow a user to anonymize a ```Dataframe``` or ```Series``` in memory.

### Changes

- [x] ```clean_pandas``` accessor on a ```pandas``` object
- [x] Options to encrypt, replace with dummy data, or truncate

### Define Done

- [x] A user can apply encryption, replacement, or truncation to any number of ```Series``` objects